### PR TITLE
Centralize the sdk & build tools versions of all module.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,11 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+
+ext {
+    buildToolsVersion = "23.0.2"
+    compileSdkVersion = 23
+    targetSdkVersion = 23
+    minSdkVersion = 16
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.library'
 apply from: '../config/quality.gradle'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     resourcePrefix 'isl_'
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }

--- a/picasso-loader/build.gradle
+++ b/picasso-loader/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Add an extension to the root project to keep track of the sdk and build tools version of all the modules.
