### PR TITLE
Add a caching mechanism for the TargetActivities

### DIFF
--- a/library/src/main/java/fr/tvbarthel/intentshare/TargetActivity.java
+++ b/library/src/main/java/fr/tvbarthel/intentshare/TargetActivity.java
@@ -1,6 +1,5 @@
 package fr.tvbarthel.intentshare;
 
-import android.content.Context;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 
@@ -23,11 +22,10 @@ class TargetActivity {
     /**
      * Plain java model for a sharing target activity.
      *
-     * @param context       context used to load target activity label.
      * @param resolveInfo   {@link ResolveInfo} linked to the target activity.
      * @param lastSelection time stamp in milli of  last selection.
      */
-    public TargetActivity(Context context, ResolveInfo resolveInfo, long lastSelection) {
+    public TargetActivity(ResolveInfo resolveInfo, long lastSelection) {
         this.lastSelection = lastSelection;
         this.resolveInfo = resolveInfo;
 

--- a/library/src/main/java/fr/tvbarthel/intentshare/TargetChooserActivity.java
+++ b/library/src/main/java/fr/tvbarthel/intentshare/TargetChooserActivity.java
@@ -140,7 +140,7 @@ public class TargetChooserActivity extends AppCompatActivity
         setUpRecyclerView(savedInstanceState);
         setUpStickyTitle();
 
-        targetActivityManager = new TargetActivityManager();
+        targetActivityManager = TargetActivityManager.getInstance();
         targetActivityManager.resolveTargetActivities(this, this);
     }
 
@@ -193,12 +193,11 @@ public class TargetChooserActivity extends AppCompatActivity
     }
 
     @Override
-    public void onLabelResolved(TargetActivity targetActivity) {
+    public void onLabelResolved(@NonNull TargetActivity targetActivity) {
         adapter.notifyTargetActivityChanged(targetActivity);
     }
 
-
-    private void setUpRecyclerView(Bundle savedInstance) {
+    private void setUpRecyclerView(final Bundle savedInstance) {
         recyclerView.setLayoutManager(
                 new LinearLayoutManager(
                         this,
@@ -226,10 +225,14 @@ public class TargetChooserActivity extends AppCompatActivity
                         int startingHeight = Math.min(totalHeight, maxStartingHeight);
                         recyclerPaddingTop = recyclerView.getHeight() - startingHeight;
                         recyclerView.setPadding(0, recyclerPaddingTop, 0, 0);
-                        recyclerView.setTranslationY(recyclerView.getHeight());
                         recyclerView.setAdapter(adapter);
-                        recyclerView.animate().translationY(0).setListener(null);
-                        return false;
+
+                        if (savedInstance == null) {
+                            recyclerView.setTranslationY(recyclerView.getHeight());
+                            recyclerView.animate().translationY(0).setListener(null);
+                        }
+
+                        return true;
                     }
                 }
         );


### PR DESCRIPTION
On some phone, resolving the label is quite long, this should shorter the resolving time for successive sharing =)

On the downside, the TargetActivityManager is now a singleton. We could also provide a static method for releasing this singleton if the client application wants to free some memory.
